### PR TITLE
Don't recognize NetworkManager if the systemd dns plugin is active

### DIFF
--- a/resolv/nm.go
+++ b/resolv/nm.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package resolv
@@ -10,6 +11,7 @@ import (
 	"github.com/kayrus/tuncfg/log"
 
 	"github.com/godbus/dbus/v5"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -165,14 +167,47 @@ func (h *Handler) setNetworkManager() error {
 	}
 	defer conn.Close()
 
-	if h.isResolve() {
+	err = updateNetworkManager(conn, h.dbusNmConnectionPath, h.dnsServers, h.dnsSuffixes)
+	if err != nil {
+		return err
+	}
+
+	if len(h.nmViaResolved) > 0 {
+		// remove default DNS server from resolved.
+		obj := conn.Object(resolveInterface, resolveObjectPath)
+		linkDns := []resolveLinkDns{
+			{
+				Family:  unix.AF_INET,
+				Address: h.dnsServers[0].To4(),
+			},
+		}
+		for k := range h.nmViaResolved {
+			err = obj.Call(resolveSetLinkDNS, 0, k, linkDns).Store()
+			if err != nil {
+				return fmt.Errorf("failed to set %q DNS servers: %v", h.dnsServers, err)
+			}
+		}
+	} else {
 		// detect DNS servers, hidden behind systemd-resolved
 		if err := h.detectRealDNS(conn); err != nil {
 			return fmt.Errorf("failed to detect original DNS servers: %v", err)
 		}
+
+		// remove default DNS server from resolved.
+		obj := conn.Object(resolveInterface, resolveObjectPath)
+		linkDns := []resolveLinkDns{
+			{
+				Family:  unix.AF_INET,
+				Address: h.dnsServers[0].To4(),
+			},
+		}
+		err = obj.Call(resolveSetLinkDNS, 0, h.iface.Index, linkDns).Store()
+		if err != nil {
+			return fmt.Errorf("failed to set %q DNS servers: %v", h.dnsServers, err)
+		}
 	}
 
-	return updateNetworkManager(conn, h.dbusNmConnectionPath, h.dnsServers, h.dnsSuffixes)
+	return nil
 }
 
 func (h *Handler) restoreNetworkManager() {

--- a/resolv/resolv.go
+++ b/resolv/resolv.go
@@ -27,7 +27,8 @@ type Handler struct {
 	dbusShillServicePath string
 	dbusNmConnectionPath string
 	// only with systemd-resolved
-	dnsDomains []string
+	dnsDomains    []string
+	nmViaResolved map[int][]net.IP
 
 	// parsed /etc/resolv.conf
 	origDnsServers  []net.IP
@@ -143,7 +144,10 @@ func (h *Handler) IsNetworkManager() bool {
 }
 
 func (h *Handler) IsResolve() bool {
-	// NetworkManager may work on top of systemd-resolved
+	// NetworkManager may work on top of systemd-resolved, but NetworkManager
+	// can also be configured to defer to systemd-resolved.
+	// The IsNetworkManager check returns false if resolved is the correct
+	// place to look.
 	if h.IsNetworkManager() {
 		return false
 	}

--- a/resolv/resolv_other.go
+++ b/resolv/resolv_other.go
@@ -50,7 +50,7 @@ func (h *Handler) Set() error {
 		return nil
 	}
 
-	// NetworkManager has a higher priority
+	// NetworkManager has a higher priority than resolved, because nm can work on top of resolved.
 	if h.IsNetworkManager() {
 		if v, ok := interface{}(h).(interface{ setNetworkManager() error }); ok {
 			return v.setNetworkManager()
@@ -113,7 +113,7 @@ func (h *Handler) Restore() {
 		return
 	}
 
-	// NetworkManager has a higher priority
+	// NetworkManager has a higher priority than resolved, because nm can work on top of resolved.
 	if h.IsNetworkManager() {
 		if v, ok := interface{}(h).(interface{ restoreNetworkManager() }); ok {
 			v.restoreNetworkManager()

--- a/resolv/resolve.go
+++ b/resolv/resolve.go
@@ -5,10 +5,12 @@ package resolv
 import (
 	"fmt"
 	"net"
+	"sort"
 	"strings"
 
 	"github.com/kayrus/tuncfg/log"
 
+	"github.com/godbus/dbus/v5"
 	"golang.org/x/sys/unix"
 )
 
@@ -16,9 +18,11 @@ const (
 	// systemd-resolved constants
 	resolveInterface      = "org.freedesktop.resolve1"
 	resolveObjectPath     = "/org/freedesktop/resolve1"
+	resolveGetLink        = resolveInterface + ".Manager.GetLink"
 	resolveSetLinkDNS     = resolveInterface + ".Manager.SetLinkDNS"
 	resolveSetLinkDomains = resolveInterface + ".Manager.SetLinkDomains"
 	resolveRevertLink     = resolveInterface + ".Manager.RevertLink"
+	resolveGetDNSProperty = resolveInterface + ".Link.DNS"
 )
 
 var resolveListenAddr = net.IPv4(127, 0, 0, 53)
@@ -34,11 +38,71 @@ type resolveLinkDomain struct {
 }
 
 func (h *Handler) isResolve() bool {
+	if len(h.nmViaResolved) > 0 {
+		return false
+	}
+
+	// detect default DNS server from resolved, when networkManager is also used
+	conn, err := newDbusConn()
+	if err != nil {
+		return false
+	}
+	defer conn.Close()
+
+	// get all interfaces
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return false
+	}
+	obj := conn.Object(resolveInterface, resolveObjectPath)
+	ifaceDNS := make(map[int][]net.IP)
+	for _, iface := range ifaces {
+		var devPath dbus.ObjectPath
+		err = obj.Call(resolveGetLink, 0, iface.Index).Store(&devPath)
+		if err != nil {
+			return false
+		}
+
+		dev := conn.Object(resolveInterface, devPath)
+		v, err := dev.GetProperty(resolveGetDNSProperty)
+		if err != nil {
+			return false
+		}
+		if v, ok := v.Value().([][]interface{}); ok {
+			for _, v := range v {
+				if v, ok := v[0].(int32); !ok {
+					continue
+				} else if v != unix.AF_INET {
+					continue
+				}
+				if len(v) > 1 {
+					if v, ok := v[1].([]byte); ok && net.IP(v).To4() != nil {
+						ifaceDNS[iface.Index] = append(ifaceDNS[iface.Index], v)
+					}
+				}
+			}
+		}
+	}
+
+	// interfaces with DNS found, pick the last one
+	if l := len(ifaceDNS); l > 0 {
+		keys := make([]int, 0, len(ifaceDNS))
+		for k := range ifaceDNS {
+			keys = append(keys, k)
+		}
+		sort.Ints(keys)
+
+		h.nmViaResolved = ifaceDNS
+		// override h.origDnsServers
+		h.origDnsServers = ifaceDNS[keys[l-1]]
+	}
+
 	for _, ip := range h.origDnsServers {
 		if ip.Equal(resolveListenAddr) {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -107,6 +171,7 @@ func (h *Handler) restoreResolve() {
 
 	obj := conn.Object(resolveInterface, resolveObjectPath)
 
+	// TODO: fix wireguard VPN DNS not being restored
 	err = obj.Call(resolveRevertLink, 0, h.iface.Index).Store()
 	if err != nil {
 		log.Errorf("%v", err)


### PR DESCRIPTION
If `NetworkManager` is active, but the configured DNS plugin is `systemd-resolved`, then `IsNetworkManager` should return `false`. The correct way to configure the system in this case is via the `systemd-resolved` interface.